### PR TITLE
pretend to be a known editor for codeium

### DIFF
--- a/src/providers/codeium.ts
+++ b/src/providers/codeium.ts
@@ -123,9 +123,9 @@ export default class Codeium extends ApiBase {
 
     const body = {
       "metadata": {
-        "ideName": "Helix",
+        "ideName": "web",
         "ideVersion": "unknown",
-        "extensionVersion": "unknown",
+        "extensionVersion": "1.6.13",
         "extensionName": "helix-gpt",
         "apiKey": this.apiKey,
         "sessionId": this.sessionId

--- a/src/providers/codeium.ts
+++ b/src/providers/codeium.ts
@@ -123,8 +123,10 @@ export default class Codeium extends ApiBase {
 
     const body = {
       "metadata": {
+        // The editor name needs to be known by codeium
         "ideName": "web",
         "ideVersion": "unknown",
+        // The version needs to a recent one, so codeium accepts it
         "extensionVersion": "1.6.13",
         "extensionName": "helix-gpt",
         "apiKey": this.apiKey,


### PR DESCRIPTION
Codeium seems to accept any editor when used with the public key

But if you use a personal key , it errors with `Ide Helix is not supported`

This pr pretends to be `web` editor so it works, version also need to be specified

The downside of this is we need to keep the version number in sync with codeium , otherwise it might error with version is too old