### PR TITLE
Fix `authCopilot` to work without `copilotApiKey` present

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ const { values } = parseArgs({
   allowPositionals: true,
 });
 
-if (!Bun.env.TEST_RUNNER?.length && !values.openaiKey?.length && !values.copilotApiKey?.length && values.handler !== "codeium") {
+if (!Bun.env.TEST_RUNNER?.length && !values.openaiKey?.length && !(values.copilotApiKey?.length || values.authCopilot) && values.handler !== "codeium") {
   throw new Error("no handler key provided")
 }
 


### PR DESCRIPTION
The purpose of auth is to obtain the key so it should not be checking for said key's presence.