### PR TITLE
fix: use stdout write instead of console.log

### DIFF
--- a/src/models/lsp.ts
+++ b/src/models/lsp.ts
@@ -130,7 +130,7 @@ export class Service {
       params
     })
 
-    console.log(`Content-Length: ${request.length}\r\n\r\n${request}`)
+    process.stdout.write(`Content-Length: ${request.length}\r\n\r\n${request}`)
     log("sent request", request)
   }
 


### PR DESCRIPTION
Some lsp-cilent cannot handle the extra line break that comes with `console.log` well.

I'm not quit sure whether is this in the lsp specification or is the client reponsibility to handle this.

