### PR TITLE
add ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/leona/helix-gpt/actions/workflows/release.yml/badge.svg)
 ![Github Release](https://img.shields.io/badge/release-v0.28-blue)
 
-Code assistant language server for [Helix](https://github.com/helix-editor/helix) with support for Copilot/OpenAI/Codeium.
+Code assistant language server for [Helix](https://github.com/helix-editor/helix) with support for Copilot/OpenAI/Codeium/Ollama.
 
 Completion example
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import codeiumAuth from "./models/codeium-auth"
 import Github from "./providers/github"
 import Openai from "./providers/openai"
 import Codeium from "./providers/codeium"
+import Ollama from "./providers/ollama"
 
 if (config.authCopilot) {
   await copilotAuth()
@@ -23,6 +24,7 @@ if (config.authCodeium) {
 assistant.registerProvider("copilot", new Github())
 assistant.registerProvider("openai", new Openai())
 assistant.registerProvider("codeium", new Codeium())
+assistant.registerProvider("ollama", new Ollama())
 
 const lsp = new Lsp.Service({
   capabilities: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,13 +67,39 @@ const { values } = parseArgs({
     codeiumApiKey: {
       type: 'string',
       default: Bun.env.CODEIUM_API_KEY ?? "d49954eb-cfba-4992-980f-d8fb37f0e942" // Public Codeium key
-    }
+    },
+    ollamaEndpoint: {
+      type: 'string',
+      // use 127.0.0.1 instead of localhost for issue with bun
+      // see: https://github.com/oven-sh/bun/issues/1425
+      default: Bun.env.OLLAMA_ENDPOINT ?? "http://127.0.0.1:11434"
+    },
+    ollamaModel: {
+      type: 'string',
+      default: Bun.env.OLLAMA_MODEL ?? "codellama"
+    },
+    ollamaContext: {
+      type: 'string',
+      default: Bun.env.OLLAMA_CONTEXT?.length ? Bun.env.OLLAMA_CONTEXT : context.ollama
+    },
+    ollamaTimeout: {
+      type: 'string',
+      default: Bun.env.OLLAMA_TIMEOUT ?? '60000',
+    },
   },
   strict: true,
   allowPositionals: true,
 });
 
-if (!Bun.env.TEST_RUNNER?.length && !values.openaiKey?.length && !values.copilotApiKey?.length && !values.authCopilot && !values.authCodeium && values.handler !== "codeium") {
+if (
+  !Bun.env.TEST_RUNNER?.length &&
+  !values.openaiKey?.length &&
+  !values.copilotApiKey?.length &&
+  !values.authCopilot &&
+  !values.authCodeium &&
+  values.handler !== "codeium" &&
+  values.handler !== "ollama"
+) {
   throw new Error("no handler key provided")
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const context = {
   openai: `Continue the input code from the language <languageId>. Only respond with code.`,
-  copilot: `<languageId> completions. Only respond with code.`
+  copilot: `<languageId> completions. Only respond with code.`,
+  ollama: `Continue the input code from the language <languageId>. Only respond with code.`
 }
 
 export const examples = [

--- a/src/providers/ollama.test.ts
+++ b/src/providers/ollama.test.ts
@@ -1,0 +1,60 @@
+import { expect, test, mock, jest } from "bun:test";
+import Ollama from "./ollama";
+
+const ollama = new Ollama();
+
+test("completion", async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          message: {
+            role: "assistant",
+            content:
+              'const name: string = "John";\nconsole.log("Hello, " + name);',
+          },
+        }),
+      ok: true,
+    }),
+  );
+
+  const result = await ollama.completion(
+    "test",
+    "file:///app/test.ts",
+    "typescript",
+    3,
+  );
+  expect(result).toEqual([
+    'const name: string = "John";\nconsole.log("Hello, " + name);'
+  ]);
+  expect(result.length).toEqual(1);
+});
+
+test("chat", async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          message: {
+            role: "assistant",
+            content: `\`\`\`typescript
+// FILEPATH: /app/test.ts
+
+if (config.authCopilot) {
+  process.exit(0)
+}
+\`\`\``,
+          },
+        }),
+      ok: true,
+    }),
+  );
+
+  const { result } = await ollama.chat(
+    "test",
+    "test",
+    "file:///app/test.ts",
+    "typescript",
+  );
+  expect(result).toEqual("\nif (config.authCopilot) {\n  process.exit(0)\n}\n");
+});

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,0 +1,98 @@
+import ApiBase from "../models/api";
+import * as types from "./ollama.types";
+import config from "../config";
+import { log } from "../utils";
+
+export default class Ollama extends ApiBase {
+  private timeout: number
+  private model: string
+
+  constructor() {
+    super({
+      url: config.ollamaEndpoint as string,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    this.timeout = parseInt(config.ollamaTimeout, 10);
+    this.model = config.ollamaModel;
+  }
+
+  async chat(
+    request: string,
+    contents: string,
+    filepath: string,
+    languageId: string,
+  ): Promise<types.Chat> {
+    const messages = [
+      {
+        "content": `You are an AI programming assistant.\nWhen asked for your name, you must respond with \"GitHub Copilot\".\nFollow the user's requirements carefully & to the letter.\n- Each code block starts with \`\`\` and // FILEPATH.\n- You always answer with ${languageId} code.\n- When the user asks you to document something, you must answer in the form of a ${languageId} code block.\nYour expertise is strictly limited to software development topics.\nFor questions not related to software development, simply give a reminder that you are an AI programming assistant.\nKeep your answers short and impersonal.`,
+        "role": "system"
+      },
+      {
+        "content": `I have the following code in the selection:\n\`\`\`${languageId}\n// FILEPATH: ${filepath.replace('file://', '')}\n${contents}`,
+        "role": "user"
+      },
+      {
+        "content": request,
+        "role": "user"
+      }
+    ]
+
+    log("prompt", messages.map(m => `role: ${m.role}\n${m.content}`).join("\n"))
+
+    const body = {
+      model: this.model,
+      stream: false,
+      messages,
+    };
+
+    const data = await this.request({
+      method: "POST",
+      body,
+      endpoint: "/api/chat",
+      timeout: this.timeout,
+    });
+
+    log("content", data.message.content)
+    
+    return types.Chat.fromResponse(data, filepath, languageId);
+  }
+
+  async completion(
+    contents: any,
+    filepath: string,
+    languageId: string,
+    suggestions = 3,
+  ): Promise<types.Completion> {
+    const messages = [
+      {
+        role: "system",
+        content: config.ollamaContext?.replace("<languageId>", languageId) + "\n\n" + `End of file context:\n\n${contents.contentAfter}`
+      },
+      {
+        role: "user",
+        content: `Start of file context:\n\n${contents.contentBefore}`
+      }
+    ]
+
+    log("prompt", messages.map(m => `role: ${m.role}\n${m.content}`).join("\n"))
+
+    const body = {
+      model: this.model,
+      stream: false,
+      messages,
+    };
+
+    const data = await this.request({
+      method: "POST",
+      body,
+      endpoint: "/api/chat",
+      timeout: this.timeout,
+    });
+
+    log("content", data.message.content)
+
+    return types.Completion.fromResponse(data);
+  }
+}

--- a/src/providers/ollama.types.ts
+++ b/src/providers/ollama.types.ts
@@ -1,0 +1,26 @@
+import { uniqueStringArray, extractCodeBlock, log } from "../utils";
+
+export class Completion extends Array<string> {
+  constructor(...items: string[]) {
+    super();
+    this.push(...uniqueStringArray(items));
+  }
+
+  static fromResponse(data: any): Completion {
+    return new Completion(data.message.content as string);
+  }
+}
+
+export class Chat {
+  result: string;
+
+  constructor(data: string) {
+    this.result = data;
+  }
+
+  static fromResponse(data: any, filepath: string, language: string): Chat {
+    const content = data.message.content as string;
+    const result = extractCodeBlock(filepath, content, language);
+    return new Chat(result as string);
+  }
+}


### PR DESCRIPTION
This PR add basic support for Ollama.

Prompts are copied from openai provider

## Testing
1. install [ollama](https://ollama.com)
2. launch ollama
3. `ollama pull codellam`
4. modify helix `languages.toml`
```toml
[[language]]
name = "go"
language-servers = ["gopls", "gpt"]

[language-server.gpt]
command = "bun"
args = [
  "--inspect=0.0.0.0:6499", 
  "run", 
  "helix-gpt/src/app.ts", 
  "--handler",
   "ollama",
   "--logFile",
   "helix-gpt.log"
]
```

## Notes
I am new to coding with LLM and just wanted to play around with using helix and local hosted ollama. 
As I don't have access to other providers for comparison, and not much experience with prompt engineering, this is just something that seems working. Please help to test it out and let me know what is missing. 

## Discussion
- for user without strong hardware, some actions with larger file may takes too long and trigger helix `Async job failed: request 8 timed out`
- prompt and parameters may need some more fine tuning