### PR TITLE
Proposal: support Deno

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,10 +1,10 @@
 [language-server.gpt]
 command = "bun"
-args = ["--inspect=0.0.0.0:6499", "run", "/app/src/app.ts", "--handler", "copilot", "--logFile", "helix-gpt.log"]
+args = ["--inspect=0.0.0.0:6499", "run", "./src/app.ts", "--handler", "codeium", "--logFile", "helix-gpt.log"]
 
 [language-server.ts]
-command = "typescript-language-server"
-args = ["--stdio"]
+command = "lspman"
+args = ["run", "typescript-language-server" ,"--stdio"]
 language-id = "javascript"
 
 [[language]]

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,10 +1,10 @@
 [language-server.gpt]
 command = "bun"
-args = ["--inspect=0.0.0.0:6499", "run", "./src/app.ts", "--handler", "codeium", "--logFile", "helix-gpt.log"]
+args = ["--inspect=0.0.0.0:6499", "run", "/app/src/app.ts", "--handler", "copilot", "--logFile", "helix-gpt.log"]
 
 [language-server.ts]
-command = "lspman"
-args = ["run", "typescript-language-server" ,"--stdio"]
+command = "typescript-language-server"
+args = ["--stdio"]
 language-id = "javascript"
 
 [[language]]

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import "./deno-compat"
 import Lsp from "./models/lsp"
 import { commands } from "./constants"
 import * as handlers from "./events"
@@ -9,6 +10,7 @@ import codeiumAuth from "./models/codeium-auth"
 import Github from "./providers/github"
 import Openai from "./providers/openai"
 import Codeium from "./providers/codeium"
+
 
 if (config.authCopilot) {
   await copilotAuth()

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,16 @@
-import "./deno-compat"
-import Lsp from "./models/lsp"
-import { commands } from "./constants"
-import * as handlers from "./events"
-import { log } from "./utils"
-import config from "./config"
-import assistant from "./models/assistant"
-import copilotAuth from "./models/copilot-auth"
-import codeiumAuth from "./models/codeium-auth"
-import Github from "./providers/github"
-import Openai from "./providers/openai"
-import Codeium from "./providers/codeium"
+import "./deno-compat.ts";
+import Lsp from "./models/lsp.ts";
+import { commands } from "./constants.ts";
+import * as handlers from "./events/index.ts";
+import { log } from "./utils.ts";
+import config from "./config.ts";
+import assistant from "./models/assistant.ts";
+import copilotAuth from "./models/copilot-auth.ts";
+import codeiumAuth from "./models/codeium-auth.ts";
+import Github from "./providers/github.ts";
+import Openai from "./providers/openai.ts";
+import Codeium from "./providers/codeium.ts";
+import process from "node:process";
 
 
 if (config.authCopilot) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
-import { context } from "./constants"
-import { runningInDeno } from "./deno-compat";
-const { parseArgs } = await import(runningInDeno() ? "./deno-compat" : "util")
+import { context } from "./constants.ts";
+import { runningInDeno } from "./deno-compat.ts";
+const { parseArgs } = await import(
+  runningInDeno() ? "./deno-compat.ts" : "util"
+);
 
 const { values } = parseArgs({
   args: Bun.argv,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
-import { parseArgs } from "util"
 import { context } from "./constants"
+import { runningInDeno } from "./deno-compat";
+const { parseArgs } = await import(runningInDeno() ? "./deno-compat" : "util")
 
 const { values } = parseArgs({
   args: Bun.argv,

--- a/src/deno-compat.ts
+++ b/src/deno-compat.ts
@@ -30,6 +30,9 @@ class Bun {
   }
 }
 
+// deno parseArgs node compat doesn't support default option currently
+// so we use a custom one for now
+// https://github.com/denoland/deno/issues/22454
 export function parseArgs(inputObject) {
   const { args, options } = inputObject;
 

--- a/src/deno-compat.ts
+++ b/src/deno-compat.ts
@@ -1,0 +1,65 @@
+import { parseArgs as nodeParseArgs } from "node:util"
+import { Buffer } from "node:buffer"
+
+export function runningInDeno(): boolean {
+  //@ts-ignore ok
+  return Boolean(globalThis.Deno)
+}
+
+function injectDenoComapt() {
+  //@ts-ignore ok
+  globalThis.Bun = new Bun()
+  globalThis.Buffer = Buffer
+}
+
+class Bun {
+  argv: string[];
+  env: Record<string, string>;
+  stdin: { stream: () => any; };
+
+  constructor() {
+    this.argv = globalThis.Deno.args;
+    this.env = new Proxy({}, {
+      get: (_target, property: string) => {
+        return globalThis.Deno.env.get(property);
+      },
+    });
+    this.stdin = {
+      stream: () => Deno.stdin.readable
+    }
+  }
+}
+
+export function parseArgs(inputObject) {
+  const { args, options } = inputObject;
+
+  // Remove default fields from options
+  const optionsWithoutDefaults = {};
+  for (const key in options) {
+    optionsWithoutDefaults[key] = { ...options[key] };
+    delete optionsWithoutDefaults[key].default;
+  }
+
+  // Run node.parseArgs() on options without default fields
+  const p = nodeParseArgs({ args, options: optionsWithoutDefaults });
+
+  // Fill missing values in p.options with defaults
+  const filledOptions = {};
+  for (const key in options) {
+    if (!p.values[key]) {
+      filledOptions[key] = options[key].default;
+      p.values[key] = options[key].default
+    }
+  }
+
+  // Update p object with filled options
+  p.options = filledOptions;
+
+  return p;
+}
+
+
+
+if (runningInDeno()) injectDenoComapt()
+
+

--- a/src/events/actions.ts
+++ b/src/events/actions.ts
@@ -1,8 +1,8 @@
-import { Service } from "../models/lsp"
-import { Event, DiagnosticSeverity } from "../models/lsp.types"
-import { commands } from "../constants"
-import assistant from "../models/assistant"
-import { log } from "../utils"
+import { Service } from "../models/lsp.ts";
+import { DiagnosticSeverity, Event } from "../models/lsp.types.ts";
+import { commands } from "../constants.ts";
+import assistant from "../models/assistant.ts";
+import { log } from "../utils.ts";
 
 export const actions = (lsp: Service) => {
   lsp.on(Event.ExecuteCommand, async ({ ctx, request }) => {

--- a/src/events/completions.ts
+++ b/src/events/completions.ts
@@ -1,8 +1,8 @@
-import { Service } from "../models/lsp"
-import { Event, DiagnosticSeverity } from "../models/lsp.types"
-import { debounce, log, getContent } from "../utils"
-import assistant from "../models/assistant"
-import config from "../config"
+import { Service } from "../models/lsp.ts";
+import { DiagnosticSeverity, Event } from "../models/lsp.types.ts";
+import { debounce, getContent, log } from "../utils.ts";
+import assistant from "../models/assistant.ts";
+import config from "../config.ts";
 
 export const completions = (lsp: Service) => {
   lsp.on(Event.Completion, async ({ ctx, request }) => {

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,2 +1,2 @@
-export * from "./actions"
-export * from "./completions"
+export * from "./actions.ts";
+export * from "./completions.ts";

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,4 +1,4 @@
-import { log } from "../utils"
+import { log } from "../utils.ts";
 
 interface Request {
   endpoint: string;

--- a/src/models/assistant.ts
+++ b/src/models/assistant.ts
@@ -1,5 +1,5 @@
-import config from "../config"
-import { log } from "../utils"
+import config from "../config.ts";
+import { log } from "../utils.ts";
 
 interface Provider {
   chat?(request: string, contents: any, filepath: string, language: string): Promise<any>

--- a/src/models/codeium-auth.ts
+++ b/src/models/codeium-auth.ts
@@ -1,4 +1,4 @@
-import Codeium from "../providers/codeium";
+import Codeium from "../providers/codeium.ts";
 
 export default async () => {
   const codeium = new Codeium();

--- a/src/models/copilot-auth.ts
+++ b/src/models/copilot-auth.ts
@@ -1,4 +1,4 @@
-import Github from "../providers/github"
+import Github from "../providers/github.ts";
 
 export default async () => {
   const github = new Github()

--- a/src/models/lsp.ts
+++ b/src/models/lsp.ts
@@ -2,6 +2,7 @@ import EventEmitter from "node:events";
 import { log } from "../utils.ts";
 import type { Buffer, Diagnostic, EventRequest, Range } from "./lsp.types.ts";
 import { DiagnosticSeverity, Event } from "./lsp.types.ts";
+import process from "node:process"
 
 export class Service {
   emitter: EventEmitter

--- a/src/models/lsp.ts
+++ b/src/models/lsp.ts
@@ -1,7 +1,7 @@
-import EventEmitter from "node:events"
-import { log } from "../utils"
-import type { Buffer, Range, Diagnostic, EventRequest } from "./lsp.types"
-import { Event, DiagnosticSeverity } from "./lsp.types"
+import EventEmitter from "node:events";
+import { log } from "../utils.ts";
+import type { Buffer, Diagnostic, EventRequest, Range } from "./lsp.types.ts";
+import { DiagnosticSeverity, Event } from "./lsp.types.ts";
 
 export class Service {
   emitter: EventEmitter

--- a/src/models/lsp.types.ts
+++ b/src/models/lsp.types.ts
@@ -1,5 +1,5 @@
-import EventEmitter from "node:events"
-import { Service } from "./lsp"
+import EventEmitter from "node:events";
+import { Service } from "./lsp.ts";
 
 export enum Event {
   DidOpen = "textDocument/didOpen",

--- a/src/providers/codeium.ts
+++ b/src/providers/codeium.ts
@@ -1,7 +1,7 @@
-import { uuid } from "../utils";
-import ApiBase from "../models/api"
-import * as types from "./codeium.types"
-import config from "../config"
+import { uuid } from "../utils.ts";
+import ApiBase from "../models/api.ts";
+import * as types from "./codeium.types.ts";
+import config from "../config.ts";
 
 const languages = {
   unspecified: 0,

--- a/src/providers/codeium.types.ts
+++ b/src/providers/codeium.types.ts
@@ -1,4 +1,5 @@
-import { uniqueStringArray } from "../utils"
+import { uniqueStringArray } from "../utils.ts";
+
 
 export class Completion extends Array<string> {
   constructor(...items: string[]) {

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,7 +1,7 @@
-import { genHexStr, currentUnixTimestamp } from "../utils";
-import ApiBase from "../models/api"
-import * as types from "./github.types"
-import config from "../config"
+import { currentUnixTimestamp, genHexStr } from "../utils.ts";
+import ApiBase from "../models/api.ts";
+import * as types from "./github.types.ts";
+import config from "../config.ts";
 
 export default class Github extends ApiBase {
 

--- a/src/providers/github.types.ts
+++ b/src/providers/github.types.ts
@@ -1,4 +1,9 @@
-import { uniqueStringArray, parseQuery, parseQueryStringToken, extractCodeBlock } from "../utils"
+import {
+  extractCodeBlock,
+  parseQuery,
+  parseQueryStringToken,
+  uniqueStringArray,
+} from "../utils.ts";
 
 export class DeviceCode {
   deviceCode: string;

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,7 +1,7 @@
-import ApiBase from "../models/api"
-import * as types from "./openai.types"
-import config from "../config"
-import { log } from "../utils"
+import ApiBase from "../models/api.ts";
+import * as types from "./openai.types.ts";
+import config from "../config.ts";
+import { log } from "../utils.ts";
 
 export default class Github extends ApiBase {
 

--- a/src/providers/openai.types.ts
+++ b/src/providers/openai.types.ts
@@ -1,4 +1,4 @@
-import { uniqueStringArray, extractCodeBlock, log } from "../utils"
+import { extractCodeBlock, log, uniqueStringArray } from "../utils.ts";
 
 export class Completion extends Array<string> {
   constructor(...items: string[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import config from "./config"
-import crypto from "crypto"
-import fs from "fs"
+import config from "./config.ts";
+import crypto from "node:crypto";
+import fs from "node:fs";
 
 const debounces: Record<string, NodeJS.Timeout> = {}
 


### PR DESCRIPTION
Let me get started with its just a proposal because I like Deno and obviously you can just ignore this.

Ok whats it this:
- This PR makes the current codebase works with deno, there are 2 main commits here
- - the first one https://github.com/leona/helix-gpt/commit/a237f6c62305c77c619b733435745d098dde5775 makes the codebase works with deno by injecting a Bun global, but it only works if deno is run like this `deno run --unstable-sloppy-imports --unstable-bare-node-builtins src/app.ts` , this works, but it have 2 issues, the deno lsp will  keep giving errors, and it can't be compiled curretnly (there is an active issue in deno)
- - the second commit https://github.com/leona/helix-gpt/commit/51dc3a9883b03d77ba4b73492e97eb3a03912d3a converts bare specifiers to specifiers that ends with `.ts` this works in both deno and bun, and it have the advantage of fixing the 2 above issues, you can now just run it with `deno run` and it can be compiled with deno

Maybe some advantages:
- https://jsr.io/ have made me think thats its nice to support multiple runtimes, and I think its the case here
- you get to use deno cool permisison model, for example the current code base only require `--allow-env --allow-net` thats a secure binary (no read or write) 
- Deno wins this round for compile size the compiled app size is 74mb vs bun smol 90mb and there is a proposal to make the user compile its own specific binary which would make this even smaller https://github.com/denoland/deno/issues/22824 