### PR TITLE
Add scripts/update-version.sh for automated version updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,23 @@ on:
     inputs:
       tag:
         type: string
-        description: What is the release tag?
-        required: true
+        description: Specify the tag
+          - major|minor|patch
+          - x|x.x|x.x.x
+        default: patch
 jobs:
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.update-version.outputs.version }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           fetch-tags: true
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -33,11 +37,19 @@ jobs:
 
       - name: Build smol
         run: bun run build:smol
-        
+
+      - name: Update version
+        id: update-version
+        run: |
+          VERSION=$(./scripts/update-version.sh ${{ github.event.inputs.tag }})
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+          echo "version=${VERSION:1}" >> $GITHUB_OUTPUT
+          git add package.json
+
       - name: Set release
         shell: bash
         run: |
-          export VERSION="${{ github.event.inputs.tag }}"
+          export VERSION="${{ env.VERSION }}"
           export ARCH=x86_64-linux
           export APP=helix-gpt
           export OUTPUT="$APP-$VERSION-$ARCH"
@@ -49,14 +61,17 @@ jobs:
         run: |
           git config --global user.name "Leon"
           git config --global user.email "leon@nx.ie"
-          sed -e 's/<release-version>/${{ github.event.inputs.tag }}/g' assets/template.md > README.md
+
+          # Create README.md with version
+          sed -e 's/<release-version>/${{ env.VERSION }}/g' assets/template.md > README.md
           git add README.md
-          git commit -m 'release: version ${{ github.event.inputs.tag }}'
-          git push origin master
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+
+          git commit -m 'release: version ${{ env.VERSION }}'
+          git push origin ${{ github.ref_name }}
+          latest_tag=$(git describe --always --tags `git rev-list --tags --max-count=1`)
           messages=$(git log $latest_tag..HEAD --pretty=format:"%h - %s")
-          git tag -m "$messages" -a ${{ github.event.inputs.tag }}
-          git push origin ${{ github.event.inputs.tag }} 
+          git tag -m "$messages" -a ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }} 
           
       - uses: actions/upload-artifact@v4
         if: vars.RUNNER != 'act'
@@ -68,6 +83,8 @@ jobs:
     name: Publish
     needs: [build]
     runs-on: ubuntu-latest
+    env:
+        VERSION: ${{ needs.build.outputs.version }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -95,18 +112,18 @@ jobs:
             tar -C `dirname $bin` -czvf dist/$filename.tar.gz --transform 's,^.*/,,g' `basename $bin`
           done
 
-          tar -czvf dist/helix-gpt-${{ github.event.inputs.tag }}-source.tar.gz -C $source .
+          tar -czvf dist/helix-gpt-${{ env.VERSION }}-source.tar.gz -C $source .
           mv dist $source/
           
       - name: Upload binaries to release
         if: vars.RUNNER != 'act'
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GH_TOKEN }}
+          repo_token: ${{ secrets.GH_TOKEN || github.token }}
           file: dist/*
           file_glob: true
-          tag: ${{ github.event.inputs.tag }}
-          release_name: "${{ github.event.inputs.tag }}"
+          tag: ${{ env.VERSION }}
+          release_name: "${{ env.VERSION }}"
           overwrite: true
       
       - name: Upload binaries as artifact

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # helix-gpt
 
 ![Build Status](https://github.com/leona/helix-gpt/actions/workflows/release.yml/badge.svg)
-![Github Release](https://img.shields.io/badge/release-v0.28-blue)
+![Github Release](https://img.shields.io/badge/release-v0.0.9-blue)
 
 Code assistant language server for [Helix](https://github.com/helix-editor/helix) with support for Copilot/OpenAI/Codeium.
 
@@ -29,17 +29,17 @@ This was made to run with [Bun](https://bun.sh/), but you can also use a precomp
 #### Without Bun
 
 ```bash
-wget https://github.com/leona/helix-gpt/releases/download/0.28/helix-gpt-0.28-x86_64-linux.tar.gz \
+wget https://github.com/leona/helix-gpt/releases/download/0.0.9/helix-gpt-0.0.9-x86_64-linux.tar.gz \
 -O /tmp/helix-gpt.tar.gz \
 && tar -zxvf /tmp/helix-gpt.tar.gz \
-&& mv helix-gpt-0.28-x86_64-linux /usr/bin/helix-gpt \
+&& mv helix-gpt-0.0.9-x86_64-linux /usr/bin/helix-gpt \
 && chmod +x /usr/bin/helix-gpt
 ```
 
 #### With Bun (tested with 1.0.25)
 
 ```bash
-wget https://github.com/leona/helix-gpt/releases/download/0.28/helix-gpt-0.28.js -O /usr/bin/helix-gpt
+wget https://github.com/leona/helix-gpt/releases/download/0.0.9/helix-gpt-0.0.9.js -O /usr/bin/helix-gpt
 ```
 
 ### Configuration

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "helix-gpt",
+  "version": "0.0.0",
   "module": "src/app.ts",
   "type": "module",
   "scripts": {

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+VERSION=${1:-patch}
+
+run_npm_version() {
+  npm version "$1" --no-git-tag-version || exit 1
+}
+
+# Check if the version is major, minor or patch
+if [[ $VERSION =~ ^(major|minor|patch)$ ]]; then
+  true
+# Check if the version is in format 0-9
+elif [[ $VERSION =~ ^[0-9]+$ ]]; then
+  VERSION="$VERSION.0.0"
+# Check if the version is in format 0-9.0-9
+elif [[ $VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+  VERSION="$VERSION.0"
+# Check if the version is in format 0-9.0-9.0-9
+elif [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  true
+else
+  echo "Invalid version format."
+  echo "  major|minor|patch"
+  echo "  x|x.x|x.x.x (e.g. 1, 1.1 or 1.0.1)"
+  echo "  defaults to patch"
+  exit 128
+fi
+
+run_npm_version "$VERSION"


### PR DESCRIPTION
## Summary of Changes

This pull request introduces an automated version update mechanism to enhance version management in the project. The key changes include:

- Addition of `scripts/update-version.sh` to automate updating the version in `package.json`.
- Enhancement of the GitHub workflow (`release.yml`) to incorporate the new script for version management.
- Ensuring the updated version is correctly passed from the build job to the publish job.

## Details of Changes

### `scripts/update-version.sh`

A new executable script, `scripts/update-version.sh`, has been added to facilitate automated version updates. This script accepts the following arguments:
- If no argument is provided, it defaults to updating the patch version.
- If `major`, `minor`, or `patch` is provided, it updates the respective version accordingly.
- Alternatively, it accepts version numbers in the format `x`, `x.x`, or `x.x.x` (e.g., `1`, `1.1`, `1.0.1`).

### GitHub Workflow Changes

The `.github/workflows/release.yml` workflow has been updated to leverage the new version update script. Notable changes include:
- Integration of the `update-version` step to execute the script and obtain the updated version.
- Modification of steps to ensure the correct version is utilized throughout the workflow.
- For the first run of the workflow, it is recommended to set a fixed version, as the initial version is currently 0.0.0. This can be achieved by utilizing the workflow input (e.g. 0.0.29, or 0.1.0).
