### PR TITLE
Only allow one active request

### DIFF
--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -38,7 +38,11 @@ export default class ApiBase {
     options: RequestInitTimeout,
     timeout: number = config.fetchTimeout): Promise<Response> {
     return new Promise(async (resolve, reject) => {
-      setTimeout(() => reject(new Error("timeout")), timeout);
+      setTimeout(() => {
+        this.controller.abort()
+        reject(new Error("timeout"))
+      }, timeout);
+
       try {
         const response = await fetch(url, options);
         resolve(response);

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -24,11 +24,13 @@ export default class ApiBase {
   private url: string;
   private headers: Record<string, string>;
   private params: Record<string, string>;
+  private controller: AbortController;
 
   constructor({ url, headers, params }: ApiBaseOptions) {
     this.url = url;
     this.headers = headers || {};
     this.params = params || {};
+    this.controller = new AbortController();
   }
 
   async fetch(
@@ -61,6 +63,10 @@ export default class ApiBase {
       requestUrl.searchParams.append(key, this.params[key]);
     });
 
+    // cancel last pending request
+    this.controller.abort();
+    this.controller = new AbortController();
+
     let opts = {
       headers: {
         ...this.headers,
@@ -68,6 +74,7 @@ export default class ApiBase {
       },
       method,
       body: null as any,
+      signal: this.controller.signal
     };
 
     if (body) {

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -46,7 +46,8 @@ export default class ApiBase {
       try {
         const response = await fetch(url, options);
         resolve(response);
-      } catch (error) {
+      } catch (error: any) {
+        if (error.name === "AbortError") reject({ message: "" });
         reject(error);
       }
     });

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -47,6 +47,7 @@ export default class ApiBase {
         const response = await fetch(url, options);
         resolve(response);
       } catch (error: any) {
+        // we canceled the request on purpose beasue there is a new one, so no need to tell the user
         if (error.name === "AbortError") reject({ message: "" });
         reject(error);
       }


### PR DESCRIPTION
fix https://github.com/leona/helix-gpt/issues/53

This pr allows only one active request at a given time, by canceling old requests when a new one is created, seems to work ok