### PR TITLE
fix: Content-Lenght in the lsp.send, use the bytesize

### DIFF
--- a/src/models/lsp.ts
+++ b/src/models/lsp.ts
@@ -130,7 +130,8 @@ export class Service {
       params
     })
 
-    console.log(`Content-Length: ${request.length}\r\n\r\n${request}`)
+    const len = (new TextEncoder()).encode(request).length
+    console.log(`Content-Length: ${len}\r\n\r\n${request}`)
     log("sent request", request)
   }
 


### PR DESCRIPTION
When the completion contains non-ASCII characters, 
`request.length` actually represents the UTF-8 characters length and does not represent the correct Content-Length,
whereas in [Helix](https://github.com/helix-editor/helix/blob/9b7dffbd613b3ba981890de78712ac0df520f145/helix-lsp/src/transport.rs#L127), the `Content-Length` represents the byte size of the request. 

For example, "你好，世界".length is 5, but its byte size is 15,.
We can use TextEncoder to convert the `request` to a Uint8Array and then get the length of the array, its represents the byte size of `request`.