### PR TITLE
feat: add initial Cody autocomplete support

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import Github from "./providers/github"
 import Openai from "./providers/openai"
 import Codeium from "./providers/codeium"
 import Ollama from "./providers/ollama"
+import Cody from "./providers/cody";
 
 if (config.authCopilot) {
   await copilotAuth()
@@ -25,6 +26,7 @@ assistant.registerProvider("copilot", new Github())
 assistant.registerProvider("openai", new Openai())
 assistant.registerProvider("codeium", new Codeium())
 assistant.registerProvider("ollama", new Ollama())
+assistant.registerProvider("cody", new Cody());
 
 const lsp = new Lsp.Service({
   capabilities: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,10 @@ const { values } = parseArgs({
       type: 'string',
       default: Bun.env.OLLAMA_TIMEOUT ?? '60000',
     },
+    codyToken: {
+      type: "string",
+      default: Bun.env.CODY_TOKEN,
+    }
   },
   strict: true,
   allowPositionals: true,
@@ -107,8 +111,10 @@ if (
   !Bun.env.TEST_RUNNER?.length &&
   !values.openaiKey?.length &&
   !values.copilotApiKey?.length &&
+  !values.codyToken?.length &&
   !values.authCopilot &&
   !values.authCodeium &&
+
   values.handler !== "codeium" &&
   values.handler !== "ollama"
 ) {

--- a/src/providers/cody.ts
+++ b/src/providers/cody.ts
@@ -1,0 +1,55 @@
+import ApiBase from "../models/api";
+import * as types from "./cody.types";
+import config from "../config";
+import { log } from "../utils";
+
+export default class Cody extends ApiBase {
+  constructor() {
+    super({
+      url: "https://sourcegraph.com",
+      headers: {
+        Authorization: `token ${config.codyToken}`,
+        "X-Sourcegraph-Should-Trace": true,
+        "Client-Name": "vscode",
+        "Client-Version": "1.26.7",
+        "User-Agent": "Cody/1.26.7",
+      },
+    });
+  }
+
+  async completion(
+    contents: any,
+    filepath: string,
+    languageId: string,
+    suggestions = 3,
+  ): Promise<types.Completion> {
+    const messages = [
+      {
+        text:
+          config.openaiContext?.replace("<languageId>", languageId) +
+          "\n\n" +
+          `End of file context:\n\n${contents.contentAfter}` +
+          "\n\n" +
+          `Start of file context:\n\n${contents.contentBefore}`,
+        speaker: "human",
+      },
+    ];
+
+    const body = {
+      maxTokensToSample: 4000,
+      temperature: suggestions > 1 ? 0.4 : 0,
+      top_p: -1,
+      messages,
+    };
+
+    const request = await this.request({
+      method: "POST",
+      body,
+      endpoint:
+        "/.api/completions/code?client-name=vscode?client-version=1.26.7",
+      timeout: 200000
+    });
+
+    return types.Completion.fromResponse(request);
+  }
+}

--- a/src/providers/cody.types.ts
+++ b/src/providers/cody.types.ts
@@ -1,0 +1,14 @@
+import { uniqueStringArray, extractCodeBlock, log } from "../utils";
+
+export class Completion extends Array<string> {
+  constructor(...items: string[]) {
+    super();
+    this.push(...uniqueStringArray(items));
+  }
+
+  static fromResponse(data: any): Completion {
+    let parsed = JSON.parse(JSON.stringify(data));
+    const result = [parsed.completion];
+    return new Completion(...result);
+  }
+}


### PR DESCRIPTION
This is a work in progress, but I wanted to add Sourcegraph Cody support inside helix-gpt. I managed to hack together a semi-working completion provider based on the API the VSCode extension uses, but I need some help to improve the usability:

- The responses seem a bit off (too Python-y from the logs, even though I was trying to use this on this repo's TypeScript codebase).
- Getting the completions is hit or miss, even if the logs have a response, it doesn't necessarily make it into helix for a suggestion.
- The timeout is absurdly high because of the above two factors.

Adding Cody support will be really cool, since the free tier comes with unlimited completions using Claude Instant (all you need is free Sourcegraph account and generate a personal token for auth).

I'm not really sure what I am missing, but since there's a couple other APIs already implemented by others, maybe they can help figure this out? Thanks!